### PR TITLE
[TASK] TYPO3 dependencies in ext_emconf.php

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = array (
   array (
     'depends' =>
     array (
-      'typo3' => '9.5.0-12.4.99',
+      'typo3' => '10.4.37-12.4.99',
     ),
     'conflicts' =>
     array (


### PR DESCRIPTION
hi @IchHabRecht 
with the changes for v12 compatibility, the extension is unfortunately no longer compatible with v9. By now probably a very rare problem, but if you still install the extension in TYPO3 v9 via the extension manager, there is no output anymore, because the TYPO3 constant TYPO3_MODE is "missing" in ext_tables.php. Would therefore suggest to increase the minimum version in the ext_emconf. 

Best Regards
Sven